### PR TITLE
CGO has to be disabled for alpine image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,8 @@ FROM golang:1.16 AS build
 WORKDIR /go/src/github.com/org/repo
 COPY . .
 
-RUN go build -o server .
+# CGO has to be disabled for alpine image
+RUN export CGO_ENABLED=0 && go build -o server .
 
 FROM build AS development
 RUN apt-get update \


### PR DESCRIPTION
Faced this issue while running your go binary with in alpine container. 
Export the following variable before building your bin

```
docker run backend
sh: can't open '/run.sh': No such file or directory
```