### PR TITLE
CGO has to be disabled for alpine image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.16 AS build
 WORKDIR /go/src/github.com/org/repo
 COPY . .
 
+ENV CGO_ENABLED=0
 RUN go build -o server .
 
 FROM build AS development


### PR DESCRIPTION
Faced this issue while running your go binary with in alpine container. 
Export the following variable before building your bin

```
docker run backend
sh: can't open '/run.sh': No such file or directory
```