### PR TITLE
Fix port in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Project structure:
 └── README.md
 ```
 
-[_docker-compose.yaml_](docker-compose.yaml)
+[_.docker/docker-compose.yaml_](.docker/docker-compose.yaml)
 ```
 services:
   backend:
@@ -34,12 +34,12 @@ services:
   proxy:
     build: proxy
     ports:
-    - 80:80
+    - 8080:80
     ...
 ```
 The compose file defines an application with three services `proxy`, `backend` and `db`.
-When deploying the application, docker-compose maps port 80 of the proxy service container to port 80 of the host as specified in the file.
-Make sure port 80 on the host is not already being in use.
+When deploying the application, docker-compose maps port 80 of the proxy service container to port 8080 of the host as specified in the file.
+Make sure port 8080 on the host is not already being in use.
 
 ## Deploy with docker-compose
 
@@ -63,14 +63,14 @@ Listing containers must show three containers running and the port mapping as be
 ```
 $ docker ps
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                  NAMES
-d6752b317e6d   compose-dev-env_proxy                 "nginx -g 'daemon of…"   About a minute ago   Up About a minute   0.0.0.0:80->80/tcp, :::80->80/tcp   compose-dev-env_proxy_1
+d6752b317e6d   compose-dev-env_proxy                 "nginx -g 'daemon of…"   About a minute ago   Up About a minute   0.0.0.0:8080->80/tcp, :::80->80/tcp   compose-dev-env_proxy_1
 70bf9182ea52   compose-dev-env_backend               "/server"                About a minute ago   Up About a minute   8000/tcp                            compose-dev-env_backend_1
 c67de604799d   mariadb                               "docker-entrypoint.s…"   About a minute ago   Up About a minute   3306/tcp                            compose-dev-env_db_1
 ```
 
-After the application starts, navigate to `http://localhost:80` in your web browser or run:
+After the application starts, navigate to `http://localhost:8080` in your web browser or run:
 ```
-$ curl localhost:80
+$ curl localhost:8080
 ["Blog post #0","Blog post #1","Blog post #2","Blog post #3","Blog post #4"]
 ```
 


### PR DESCRIPTION
@glours When creating a dev env from this repo the compose file used is `.docker/docker-compose.yaml` and not the one at the root of the directory. Therefore we need to update the README.md accordingly to update the proxy port to `8080` instead of `80`.

```bash
curl localhost:8080
["Blog post #0","Blog post #1","Blog post #2","Blog post #3","Blog post #4"]
```